### PR TITLE
stops async operations from causing an auto-play action

### DIFF
--- a/internal/service/handlers/play.go
+++ b/internal/service/handlers/play.go
@@ -49,6 +49,7 @@ func Play() HandleMessageCreate {
 
 type audioStream struct {
 	pid              service.PlaylistID
+	pslc             time.Time
 	srcVideoUrlStr   string
 	size             int64
 	ytApiClient      *youtube.Client
@@ -111,6 +112,11 @@ func (rc *readCloser) Close() error {
 func (as *audioStream) PlaylistID() string {
 	return as.pid.String()
 }
+
+func (as *audioStream) PlayerStateLastChangedAt() time.Time {
+	return as.pslc
+}
+
 func (as *audioStream) SrcUrlStr() string {
 	return as.srcVideoUrlStr
 }
@@ -473,6 +479,7 @@ func newYoutubeDownloadClient() *youtube.Client {
 
 func handlePlayRequest(ctx context.Context, s *discordgo.Session, m *discordgo.MessageCreate, p *service.Player, args map[string]string) error {
 	pid := p.PlaylistID()
+	pslc := p.StateLastChangedAt()
 
 	urlStr := args["url"]
 
@@ -486,6 +493,7 @@ func handlePlayRequest(ctx context.Context, s *discordgo.Session, m *discordgo.M
 		mention := m.Author.Mention()
 		play = func(as *audioStream) {
 			as.pid = pid
+			as.pslc = pslc
 			pc := service.PlayCall{
 				MessageCreate: m,
 				AuthorID:      m.Message.Author.ID,

--- a/internal/service/handlers/play.go
+++ b/internal/service/handlers/play.go
@@ -475,19 +475,62 @@ func handlePlayRequest(ctx context.Context, s *discordgo.Session, m *discordgo.M
 	urlStr := args["url"]
 
 	pid := p.PlaylistID()
+	playPack := make(chan service.PlayCall, 1)
 
-	if handled, err := processPlaylist(ctx, pid, s, m, p, urlStr); err != nil {
+	p.Enqueue(playPack)
+
+	var play func(as service.AudioStreamer)
+	{
+		mention := m.Author.Mention()
+		play = func(as service.AudioStreamer) {
+			playPack <- service.PlayCall{
+				MessageCreate: m,
+				AuthorID:      m.Message.Author.ID,
+				AuthorMention: mention,
+				AudioStreamer: as,
+			}
+		}
+	}
+
+	var closePlayPack func()
+	{
+		var oncer sync.Once
+		closePlayPack = func() {
+			oncer.Do(func() {
+				close(playPack)
+			})
+		}
+	}
+
+	// ensure the channel is absolutely always closed even if something panics
+	defer func() {
+		if r := recover(); r != nil {
+			defer panic(r)
+
+			defer closePlayPack()
+
+			log.Ctx(ctx).Error().
+				Err(errors.New("panicking")).
+				Msg("this should never happen: open a ticket")
+		}
+	}()
+
+	if handled, err := processPlaylist(ctx, pid, s, m, p, play, closePlayPack, urlStr); err != nil {
+		closePlayPack()
 		return err
 	} else if handled {
+		// handling async, don't close the play package
 		return nil
 	}
 
-	return playAfterTranscode(ctx, pid, s, m, p, urlStr)
+	defer closePlayPack()
+
+	return playAfterTranscode(ctx, pid, s, m, p, play, urlStr)
 }
 
 var ErrPanicInPlaylistLoader = errors.New("Panic in playlist loader")
 
-func processPlaylist(ctx context.Context, pid service.PlaylistID, s *discordgo.Session, m *discordgo.MessageCreate, p *service.Player, urlStr string) (bool, error) {
+func processPlaylist(ctx context.Context, pid service.PlaylistID, s *discordgo.Session, m *discordgo.MessageCreate, p *service.Player, play func(service.AudioStreamer), closePlayPack func(), urlStr string) (bool, error) {
 	var result bool
 
 	ac := newYoutubeApiClient()
@@ -547,6 +590,7 @@ func processPlaylist(ctx context.Context, pid service.PlaylistID, s *discordgo.S
 	p.RegisterCanceler(extCancel)
 	go func() {
 		defer wg.Done()
+		defer closePlayPack()
 
 		var err error
 		defer func() {
@@ -594,8 +638,6 @@ func processPlaylist(ctx context.Context, pid service.PlaylistID, s *discordgo.S
 				return errors.New("youtube playlist was empty")
 			}
 
-			mention := m.Author.Mention()
-
 			var numFailed, numSuccess int
 			for _, v := range pl.Videos {
 				if ctx.Err() != nil {
@@ -624,7 +666,8 @@ func processPlaylist(ctx context.Context, pid service.PlaylistID, s *discordgo.S
 				if ctx.Err() != nil {
 					return err
 				}
-				p.Play(m, m.Message.Author.ID, mention, as)
+
+				play(as)
 			}
 
 			if numFailed > 0 {
@@ -641,7 +684,7 @@ func processPlaylist(ctx context.Context, pid service.PlaylistID, s *discordgo.S
 	return result, nil
 }
 
-func playAfterTranscode(ctx context.Context, pid service.PlaylistID, s *discordgo.Session, m *discordgo.MessageCreate, p *service.Player, urlStr string) error {
+func playAfterTranscode(ctx context.Context, pid service.PlaylistID, s *discordgo.Session, m *discordgo.MessageCreate, p *service.Player, play func(service.AudioStreamer), urlStr string) error {
 
 	if urlStr == "" {
 		return nil
@@ -670,7 +713,13 @@ func playAfterTranscode(ctx context.Context, pid service.PlaylistID, s *discordg
 		ytDownloadClient: newYoutubeDownloadClient(),
 	}
 
-	return play(ctx, p, m, as)
+	if err := as.SelectDownloadURL(ctx); err != nil {
+		return err
+	}
+
+	play(as)
+
+	return nil
 }
 
 func findVoiceChannel(s *discordgo.Session, m *discordgo.MessageCreate, p *service.Player) (*discordgo.VoiceConnection, error) {
@@ -735,19 +784,4 @@ func findVoiceChannel(s *discordgo.Session, m *discordgo.MessageCreate, p *servi
 	p.SetVoiceConnection(m, chanID, result)
 
 	return result, nil
-}
-
-// play can be called multiple times
-// when the cacheDir is not empty then the file will be playable
-func play(ctx context.Context, p *service.Player, m *discordgo.MessageCreate, as service.AudioStreamer) error {
-
-	if v, ok := as.(interface{ SelectDownloadURL(context.Context) error }); ok && v != nil {
-		if err := v.SelectDownloadURL(ctx); err != nil {
-			return err
-		}
-	}
-
-	p.Play(m, m.Message.Author.ID, m.Author.Mention(), as)
-
-	return nil
 }


### PR DESCRIPTION
This assumes that the first play callback happens basically immediately, so there is still some racing opportunity. Ideally there would be a playlist id and last state transition id/clock sequence to avoid letting a playlist play command start playing again / creating additional state transitions beyond the initial context. Then again, perhaps the right thing is to offer an `add` command that adds yt playlist elements or a track to the true playlist without changing operational states.

This works for the most part at the moment and allows for a better user experience.

Also playlist expansion should probably be cached so attempting to play the same playlist again results in less metadata fetching errors over time.

Edit: Did all the things I discussed above except for playlist caching and expansion; also still no "add" or "enqueue" keyword.