### PR TITLE
can cache playlists now

### DIFF
--- a/internal/service/handlers/cache.go
+++ b/internal/service/handlers/cache.go
@@ -8,10 +8,109 @@ import (
 	"os"
 	"regexp"
 	"sync"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/josephcopenhaver/melody-bot/internal/service"
+	"github.com/josephcopenhaver/melody-bot/internal/service/server/reactions"
+	"github.com/rs/zerolog/log"
 )
+
+type serialTaskRunner struct {
+	rwm       sync.RWMutex
+	startedAt time.Time
+	wg        sync.WaitGroup
+	taskChan  chan func(context.Context)
+}
+
+func newSerialTaskRunner(size int) *serialTaskRunner {
+	return &serialTaskRunner{
+		taskChan: make(chan func(context.Context), size),
+	}
+}
+
+func (tr *serialTaskRunner) Enqueue(f func(context.Context)) {
+	tr.taskChan <- f
+}
+
+func (tr *serialTaskRunner) Wait() {
+	tr.wg.Wait()
+}
+
+func (tr *serialTaskRunner) Start(ctx context.Context) {
+	tr.rwm.RLock()
+	cleanup := tr.rwm.RUnlock
+	defer func() {
+		if f := cleanup; f != nil {
+			cleanup = nil
+			f()
+		}
+	}()
+
+	if !tr.startedAt.IsZero() {
+		return
+	}
+
+	if f := cleanup; f != nil {
+		cleanup = nil
+		f()
+	}
+
+	tr.rwm.Lock()
+	cleanup = tr.rwm.Unlock
+
+	if !tr.startedAt.IsZero() {
+		return
+	}
+
+	wg := &tr.wg
+
+	taskChan := tr.taskChan
+
+	ctxDone := ctx.Done()
+	wg.Add(1)
+	tr.startedAt = time.Now()
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-ctxDone:
+				return
+			default:
+			}
+			select {
+			case <-ctxDone:
+				return
+			case f := <-taskChan:
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							err, ok := r.(error)
+							if !ok {
+								err = errors.New("cause unknown")
+							}
+							log.Err(err).
+								Msg("panic in serial downloader")
+						}
+					}()
+
+					f(ctx)
+				}()
+			}
+		}
+	}()
+}
+
+var serialDownloader *serialTaskRunner
+
+func init() {
+	serialDownloader = newSerialTaskRunner(128)
+}
+
+func SerialDownloader() *serialTaskRunner {
+	return serialDownloader
+}
 
 func Cache() HandleMessageCreate {
 
@@ -27,6 +126,10 @@ func Cache() HandleMessageCreate {
 				u, err := url.Parse(args["url"])
 				if err != nil {
 					return err
+				}
+
+				if u.Path == "/playlist" || u.Path == "/playlist/" {
+					return downloadPlaylistAudioStreamsAsync(ctx, p, u.String())
 				}
 
 				return downloadAudioStreamAsync(ctx, p, u.String())
@@ -45,55 +148,75 @@ func downloadAudioStreamAsync(ctx context.Context, p *service.Player, urlStr str
 		ytDownloadClient: newYoutubeDownloadClient(),
 	}
 
-	// establish the dstFilePath via the download url
-	if err := as.SelectDownloadURL(ctx); err != nil {
+	SerialDownloader().
+		Enqueue(asyncDownloadFunc(p, as))
+
+	return nil
+}
+
+func downloadPlaylistAudioStreamsAsync(ctx context.Context, p *service.Player, urlStr string) error {
+
+	sd := SerialDownloader()
+
+	ac := newYoutubeApiClient()
+
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 
-	if inf, err := os.Stat(as.dstFilePath); err != nil {
-		if !os.IsNotExist(err) {
+	pl, err := ac.GetPlaylistContext(ctx, urlStr)
+	if err != nil {
+		return fmt.Errorf("failed to download playlist: %w", err)
+	}
+
+	if len(pl.Videos) == 0 {
+		return errors.New("youtube playlist was empty")
+	}
+
+	var numFailed, numSuccess int
+	for _, v := range pl.Videos {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
-	} else if inf.IsDir() {
-		return errors.New("cannot download: destination file exists as a directory")
-	} else {
-		p.BroadcastTextMessage(fmt.Sprintf("audio file for %s is already cached", urlStr))
-		return nil
+
+		as := &audioStream{
+			srcVideoUrlStr:   fmt.Sprintf("https://www.youtube.com/watch?v=%s", url.QueryEscape(v.ID)),
+			ytApiClient:      ac,
+			ytDownloadClient: newYoutubeDownloadClient(),
+		}
+
+		if err := as.SelectDownloadURL(ctx); err != nil {
+			log.Ctx(ctx).Err(err).
+				Str("track", as.srcVideoUrlStr).
+				Msg("failed to select download url")
+
+			p.BroadcastTextMessage("Failed to queue " + as.srcVideoUrlStr)
+
+			numFailed += 1
+			continue
+		}
+
+		numSuccess += 1
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		sd.Enqueue(asyncDownloadFunc(p, as))
 	}
 
-	var extCancel *func(error)
-	var cancel func(error)
-	var wg sync.WaitGroup
-	{
-		var cancelCauseFunc context.CancelCauseFunc
-		ctx, cancelCauseFunc = context.WithCancelCause(ctx)
-		var oncer sync.Once
-		cancel = func(err error) {
-			oncer.Do(func() {
-				p.DeregisterCanceler(extCancel)
-
-				if cerr := ctx.Err(); cerr != nil {
-					err = cerr
-				}
-
-				cancelCauseFunc(err)
-			})
+	if numFailed > 0 {
+		if numSuccess == 0 {
+			return fmt.Errorf("all %d tracks could not be imported from playlist", numFailed)
 		}
-		f := func(err error) {
-			defer wg.Wait()
-
-			cancel(err)
-		}
-		extCancel = &f
+		return reactions.NewWarning(fmt.Errorf("%d out of %d tracks could not be imported from playlist", numFailed, numFailed+numSuccess))
 	}
 
-	// download and transcode the file
+	return nil
+}
 
-	wg.Add(1)
-	p.RegisterCanceler(extCancel)
-	go func() {
-		defer wg.Done()
-
+func asyncDownloadFunc(p *service.Player, as *audioStream) func(context.Context) {
+	return func(ctx context.Context) {
 		var err error
 		defer func() {
 			if err == nil {
@@ -111,14 +234,29 @@ func downloadAudioStreamAsync(ctx context.Context, p *service.Player, urlStr str
 			}
 
 			p.BroadcastTextMessage(err.Error())
-
-			cancel(err)
 		}()
 
-		if e := as.DownloadAndTranscode(ctx); e != nil {
-			err = fmt.Errorf("cache: download and transcode process for %s failed: %w", urlStr, e)
+		// establish the dstFilePath via the download url
+		if e := as.SelectDownloadURL(ctx); e != nil {
+			err = e
+			return
 		}
-	}()
 
-	return nil
+		if inf, e := os.Stat(as.dstFilePath); e != nil {
+			if !os.IsNotExist(e) {
+				err = e
+				return
+			}
+		} else if inf.IsDir() {
+			err = errors.New("cannot download: destination file exists as a directory")
+			return
+		} else {
+			p.BroadcastTextMessage(fmt.Sprintf("audio file for %s is already cached", as.srcVideoUrlStr))
+			return
+		}
+
+		if e := as.DownloadAndTranscode(ctx); e != nil {
+			err = fmt.Errorf("cache: download and transcode process for %s failed: %w", as.srcVideoUrlStr, e)
+		}
+	}
 }

--- a/internal/service/handlers/cache.go
+++ b/internal/service/handlers/cache.go
@@ -185,7 +185,7 @@ func downloadPlaylistAudioStreamsAsync(ctx context.Context, p *service.Player, u
 			ytDownloadClient: newYoutubeDownloadClient(),
 		}
 
-		if err := as.SelectDownloadURL(ctx); err != nil {
+		if err := as.SelectDownloadURLWithFallbackApiClient(ctx, newYoutubeApiClient); err != nil {
 			log.Ctx(ctx).Err(err).
 				Str("track", as.srcVideoUrlStr).
 				Msg("failed to select download url")

--- a/internal/service/handlers/play.go
+++ b/internal/service/handlers/play.go
@@ -376,7 +376,7 @@ func (as *audioStream) ReadCloser(ctx context.Context, wg *sync.WaitGroup) (io.R
 	cacheDir := path.Dir(as.dstFilePath)
 
 	if err := os.MkdirAll(cacheDir, os.ModePerm); err != nil {
-		return nil, fmt.Errorf("failed to make cache directory: %s: %v", cacheDir, err)
+		return nil, fmt.Errorf("failed to make cache directory: %s: %w", cacheDir, err)
 	}
 
 	tmpF, err := ioutil.TempFile(cacheDir, "melody-bot.*.audio.s16le.tmp")
@@ -564,7 +564,7 @@ func (as *audioStream) DownloadAndTranscode(ctx context.Context) error {
 	cacheDir := path.Dir(as.dstFilePath)
 
 	if err := os.MkdirAll(cacheDir, os.ModePerm); err != nil {
-		return fmt.Errorf("failed to make cache directory: %s: %v", cacheDir, err)
+		return fmt.Errorf("failed to make cache directory: %s: %w", cacheDir, err)
 	}
 
 	tmpF, err := ioutil.TempFile(cacheDir, "melody-bot.*.audio.s16le.tmp")
@@ -856,7 +856,7 @@ func processPlaylist(ctx context.Context, s *discordgo.Session, m *discordgo.Mes
 			{
 				c, err := findVoiceChannel(s, m, p)
 				if err != nil {
-					return fmt.Errorf("failed to auto-join a voice channel: %v", err)
+					return fmt.Errorf("failed to auto-join a voice channel: %w", err)
 				}
 
 				if c == nil {
@@ -928,7 +928,7 @@ func playAfterTranscode(ctx context.Context, s *discordgo.Session, m *discordgo.
 	{
 		c, err := findVoiceChannel(s, m, p)
 		if err != nil {
-			return fmt.Errorf("failed to auto-join a voice channel: %v", err)
+			return fmt.Errorf("failed to auto-join a voice channel: %w", err)
 		}
 
 		if c == nil {

--- a/internal/service/handlers/play.go
+++ b/internal/service/handlers/play.go
@@ -175,6 +175,11 @@ func (as *audioStream) SrcUrlStr() string {
 }
 
 func (as *audioStream) SelectDownloadURL(ctx context.Context) error {
+	return as.SelectDownloadURLWithFallbackApiClient(ctx, nil)
+}
+
+// SelectDownloadURLWithFallbackApiClient is a jenky test that can modify the state of the audioStream apiClient if newApiClient is non-nil
+func (as *audioStream) SelectDownloadURLWithFallbackApiClient(ctx context.Context, newApiClient func() *youtube.Client) error {
 
 	// protect against getting called more than once
 	if as.Video != nil {
@@ -229,6 +234,11 @@ func (as *audioStream) SelectDownloadURL(ctx context.Context) error {
 				newReader.Close()
 			}
 			if newSize == 0 {
+				if f := newApiClient; f != nil {
+					if v := f(); v != nil {
+						as.ytApiClient = v
+					}
+				}
 				// try again, there is a bug in the client implementation
 				newReader, newSize, err = as.ytApiClient.GetStreamContext(ctx, ytVid, &n)
 				if err != nil {

--- a/internal/service/player.go
+++ b/internal/service/player.go
@@ -1050,7 +1050,7 @@ func (p *Player) playerStateMachine() error {
 
 	f, err := track.ReadCloser(ctx, p.wg)
 	if err != nil {
-		return fmt.Errorf("failed to open audio stream: %s, %t: %v", track.SrcUrlStr(), track.Cached(), err)
+		return fmt.Errorf("failed to open audio stream: %s, %t: %w", track.SrcUrlStr(), track.Cached(), err)
 	}
 	defer f.Close()
 
@@ -1206,7 +1206,7 @@ func (p *Player) playerStateMachine() error {
 
 				return nil
 			}
-			return fmt.Errorf("error reading track: %s: %v", track.SrcUrlStr(), err)
+			return fmt.Errorf("error reading track: %s: %w", track.SrcUrlStr(), err)
 		}
 
 		numBytes, err := opusEncoder.Encode(pcmBuf[:], SampleSize, packet)
@@ -1232,7 +1232,7 @@ func (p *Player) playerStateMachine() error {
 		}
 
 		if err != nil {
-			return fmt.Errorf("error encoding track to opus: %s: %v", track.SrcUrlStr(), err)
+			return fmt.Errorf("error encoding track to opus: %s: %w", track.SrcUrlStr(), err)
 		}
 	}
 }

--- a/internal/service/player.go
+++ b/internal/service/player.go
@@ -489,7 +489,7 @@ func (p *Player) reset() {
 
 			var wg sync.WaitGroup
 			wg.Add(len(oldMap))
-			for k, _ := range oldMap {
+			for k := range oldMap {
 				k := k
 
 				go func() {


### PR DESCRIPTION
Caching operation runs serial per instance of the bot. At most one download+transcode workflow can happen at a time, and at most one download+trascode+play workflow can happen at a time.

So all in all, at most two concurrent transcodes if using both the cache command and the play command.